### PR TITLE
Feat/payment selection

### DIFF
--- a/src/components/DefaultTabStyle.js
+++ b/src/components/DefaultTabStyle.js
@@ -25,15 +25,16 @@ const Option = styled.div`
   width: fit-content;
   min-height: 145px;
   height: fit-content;
-  border: 1px solid #CECECE;
+  border: ${props => props.selected ? "none" : "1px solid #CECECE"};
   border-radius: 20px;
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
+  background-color: ${props => props.selected ? "#FFEED2" : "transparent"};
   
   &:hover {
-    filter: brightness(0.);
+    filter: brightness(0.95);
     cursor: pointer;
   }
 `;

--- a/src/components/DefaultTabStyle.js
+++ b/src/components/DefaultTabStyle.js
@@ -12,6 +12,10 @@ const PageSubtitle = styled.h2`
   color: #8E8E8E;
   display: ${props => props.visible ? "inblock" : "none"};
   margin-bottom: 15px;
+
+  & span {
+    font-weight: 700;
+  }
 `;
 
 const Options = styled.div`

--- a/src/components/DefaultTabStyle.js
+++ b/src/components/DefaultTabStyle.js
@@ -10,14 +10,16 @@ const PageSubtitle = styled.h2`
   font-family: 'Roboto', sans-serif;
   font-size: 20px;
   color: #8E8E8E;
+  display: ${props => props.visible ? "inblock" : "none"};
   margin-bottom: 15px;
 `;
 
 const Options = styled.div`
   width: fit-content;
-  display: grid;
+  display: ${props => props.visible ? "grid" : "none"};
   grid-template-columns: repeat(2, 1fr);
   column-gap: 25px;
+  margin-bottom: 45px;
 `;
 
 const Option = styled.div`

--- a/src/components/Form/Button.js
+++ b/src/components/Form/Button.js
@@ -11,4 +11,5 @@ export default function Button({ variant="contained", children, ...props }) {
 
 const StyledMuiButton = styled(MuiButton)`
   margin-top: 8px !important;
+  display: ${props => props.visible ? "" : "none"};
 `;

--- a/src/components/Form/Button.js
+++ b/src/components/Form/Button.js
@@ -11,5 +11,4 @@ export default function Button({ variant="contained", children, ...props }) {
 
 const StyledMuiButton = styled(MuiButton)`
   margin-top: 8px !important;
-  display: ${props => props.visible ? "" : "none"};
 `;

--- a/src/pages/Dashboard/Payment/HotelSelection.js
+++ b/src/pages/Dashboard/Payment/HotelSelection.js
@@ -1,0 +1,31 @@
+import {
+  PageSubtitle,
+  Options,
+  Option,
+  Type,
+  Price,
+} from "../../../components/DefaultTabStyle";
+
+export default function HotelSelection({ ticket, hasHotel, setHasHotel }) {
+  return (
+    <>
+      <PageSubtitle visible={ticket === "presential" ? true : false}>Ótimo! Agora escolha sua modalidade de hospedagem</PageSubtitle>
+      <Options visible={ticket === "presential" ? true : false}>
+        <Option
+          selected={hasHotel === "no" ? true : false}
+          onClick={() => hasHotel === "no" ? setHasHotel(null) : setHasHotel("no")}
+        >
+          <Type>Sem Hotel</Type>
+          <Price>+ R$ 0</Price>
+        </Option>
+        <Option
+          selected={hasHotel === "yes" ? true : false}
+          onClick={() => hasHotel === "yes" ? setHasHotel(null) : setHasHotel("yes")}
+        >
+          <Type>Com Hotel</Type>
+          <Price>+ R$ 350</Price>
+        </Option>
+      </Options>
+    </>
+  );
+}

--- a/src/pages/Dashboard/Payment/ModalitySelection.js
+++ b/src/pages/Dashboard/Payment/ModalitySelection.js
@@ -1,0 +1,66 @@
+import { useState, useEffect } from "react";
+import styled from "styled-components";
+import { toast } from "react-toastify";
+import TicketSelection from "./TicketSelection";
+import HotelSelection from "./HotelSelection";
+import { PageSubtitle } from "../../../components/DefaultTabStyle";
+import Button from "../../../components/Form/Button";
+
+export default function ModalitySelection({ setModalityInfo, setPaymentVisibility }) {
+  const [ticket, setTicket] = useState(null);
+  const [hasHotel, setHasHotel] = useState(null);
+  const [total, setTotal] = useState(0);
+  const [modalityVisibility, setModalityVisibility] = useState(true);
+
+  useEffect(() => {
+    const ticketValue = ticket === "presential" ? 250 : 100;
+    const hotelValue = hasHotel === "yes" ? 350 : 0;
+
+    setTotal(ticketValue + hotelValue);
+  }, [hasHotel, ticket]);
+
+  const storeTicketAndHotelInfo = () => {
+    if (!ticket || !hasHotel) {
+      toast("Selecione os dados pedidos corretamente");
+    }
+    const data = {
+      modality: ticket,
+      acommodation: hasHotel,
+    };
+    setModalityInfo(data);
+    setModalityVisibility(false);
+    setPaymentVisibility(true);
+  };
+
+  return (
+    <ModalityContainer visible={modalityVisibility}>
+      <TicketSelection
+        ticket={ticket}
+        setTicket={setTicket}
+        setHasHotel={setHasHotel}
+      />
+      <HotelSelection
+        ticket={ticket}
+        hasHotel={hasHotel}
+        setHasHotel={setHasHotel}
+      />
+      <PageSubtitle
+        visible={ticket === "online" || (ticket === "presential" && hasHotel) ? 1 : undefined}
+      >Fechado! O total ficou em <span>R$ {total}</span>. Agora é só confirmar:</PageSubtitle>
+      <ToPaymentButton
+        visible={ticket === "online" || (ticket === "presential" && hasHotel) ? 1 : undefined}
+        onClick={storeTicketAndHotelInfo}
+      >
+            RESERVAR INGRESSO
+      </ToPaymentButton>
+    </ModalityContainer>
+  );
+}
+
+const ToPaymentButton = styled(Button)`
+  display: ${props => props.visible ? "inblock" : "none !important"};
+`;
+
+const ModalityContainer = styled.section`
+  display: ${props => props.visible ? "" : "none"};
+`;

--- a/src/pages/Dashboard/Payment/PaymentSelection.js
+++ b/src/pages/Dashboard/Payment/PaymentSelection.js
@@ -1,0 +1,13 @@
+import styled from "styled-components";
+
+export default function PaymentSelection({ modalityInfo, paymentVisibility }) {
+  return (
+    <PaymentContainer visible={paymentVisibility}>
+      Este espaço é destinado para a lógica de pagamento! :)
+    </PaymentContainer>
+  );
+}
+
+const PaymentContainer = styled.section`
+  display: ${props => props.visible ? "" : "none"};
+`;

--- a/src/pages/Dashboard/Payment/TicketSelection.js
+++ b/src/pages/Dashboard/Payment/TicketSelection.js
@@ -1,0 +1,37 @@
+import {
+  PageSubtitle,
+  Options,
+  Option,
+  Type,
+  Price,
+} from "../../../components/DefaultTabStyle";
+
+export default function TicketSelection({ ticket, setTicket, setHasHotel }) {
+  return (
+    <>
+      <PageSubtitle visible={true}>Primeiro, escolha sua modalidade de ingresso</PageSubtitle>
+      <Options visible={true}>
+        <Option
+          selected={ticket === "presential" ? true : false}
+          onClick={() => {
+            ticket === "presential" ? setTicket(null) : setTicket("presential");
+            setHasHotel(null);
+          }}
+        >
+          <Type>Presencial</Type>
+          <Price>R$ 250</Price>
+        </Option>
+        <Option
+          selected={ticket === "online" ? true : false}
+          onClick={() => {
+            ticket === "online" ? setTicket(null) : setTicket("online");
+            setHasHotel(null);
+          }}
+        >
+          <Type>Online</Type>
+          <Price>R$ 100</Price>
+        </Option>
+      </Options>
+    </>
+  );
+}

--- a/src/pages/Dashboard/Payment/TicketSelection.js
+++ b/src/pages/Dashboard/Payment/TicketSelection.js
@@ -25,7 +25,7 @@ export default function TicketSelection({ ticket, setTicket, setHasHotel }) {
           selected={ticket === "online" ? true : false}
           onClick={() => {
             ticket === "online" ? setTicket(null) : setTicket("online");
-            setHasHotel(null);
+            setHasHotel("no");
           }}
         >
           <Type>Online</Type>

--- a/src/pages/Dashboard/Payment/index.js
+++ b/src/pages/Dashboard/Payment/index.js
@@ -16,6 +16,7 @@ export default function Payment() {
   const [hasSubscription, setHasSubscription] = useState("");
   const [loading, setLoading] = useState(false);
   const [ticket, setTicket] = useState(null);
+  const [hasHotel, setHasHotel] = useState(null);
   const { enrollment } = useApi();
 
   useEffect(() => { 
@@ -37,21 +38,44 @@ export default function Payment() {
       <PageTitle>Ingresso e pagamento</PageTitle>
       {hasSubscription ?
         <>
-          <PageSubtitle>Primeiro, escolha sua modalidade de ingresso</PageSubtitle>
-          <Options>
+          <PageSubtitle visible={true}>Primeiro, escolha sua modalidade de ingresso</PageSubtitle>
+          <Options visible={true}>
             <Option
               selected={ticket === "presential" ? true : false}
-              onClick={() => ticket === "presential" ? setTicket(null) : setTicket("presential")}
+              onClick={() => {
+                ticket === "presential" ? setTicket(null) : setTicket("presential");
+                setHasHotel(null);
+              }}
             >
               <Type>Presencial</Type>
-              <Price>R$250</Price>
+              <Price>R$ 250</Price>
             </Option>
             <Option
               selected={ticket === "online" ? true : false}
-              onClick={() => ticket === "online" ? setTicket(null) : setTicket("online")}
+              onClick={() => {
+                ticket === "online" ? setTicket(null) : setTicket("online");
+                setHasHotel(null);
+              }}
             >
               <Type>Online</Type>
-              <Price>R$100</Price>
+              <Price>R$ 100</Price>
+            </Option>
+          </Options>
+          <PageSubtitle visible={ticket === "presential" ? true : false}>Ótimo! Agora escolha sua modalidade de hospedagem</PageSubtitle>
+          <Options visible={ticket === "presential" ? true : false}>
+            <Option
+              selected={hasHotel === "no" ? true : false}
+              onClick={() => hasHotel === "no" ? setHasHotel(null) : setHasHotel("no")}
+            >
+              <Type>Sem Hotel</Type>
+              <Price>+ R$ 0</Price>
+            </Option>
+            <Option
+              selected={hasHotel === "yes" ? true : false}
+              onClick={() => hasHotel === "yes" ? setHasHotel(null) : setHasHotel("yes")}
+            >
+              <Type>Com Hotel</Type>
+              <Price>+ R$ 350</Price>
             </Option>
           </Options>
         </> :

--- a/src/pages/Dashboard/Payment/index.js
+++ b/src/pages/Dashboard/Payment/index.js
@@ -11,6 +11,7 @@ import {
   Center,
   BlockedText,
 } from "../../../components/DefaultTabStyle";
+import TicketSelection from "./TicketSelection";
 
 export default function Payment() {
   const [hasSubscription, setHasSubscription] = useState("");
@@ -38,29 +39,11 @@ export default function Payment() {
       <PageTitle>Ingresso e pagamento</PageTitle>
       {hasSubscription ?
         <>
-          <PageSubtitle visible={true}>Primeiro, escolha sua modalidade de ingresso</PageSubtitle>
-          <Options visible={true}>
-            <Option
-              selected={ticket === "presential" ? true : false}
-              onClick={() => {
-                ticket === "presential" ? setTicket(null) : setTicket("presential");
-                setHasHotel(null);
-              }}
-            >
-              <Type>Presencial</Type>
-              <Price>R$ 250</Price>
-            </Option>
-            <Option
-              selected={ticket === "online" ? true : false}
-              onClick={() => {
-                ticket === "online" ? setTicket(null) : setTicket("online");
-                setHasHotel(null);
-              }}
-            >
-              <Type>Online</Type>
-              <Price>R$ 100</Price>
-            </Option>
-          </Options>
+          <TicketSelection
+            ticket={ticket}
+            setTicket={setTicket}
+            setHasHotel={setHasHotel}
+          />
           <PageSubtitle visible={ticket === "presential" ? true : false}>Ótimo! Agora escolha sua modalidade de hospedagem</PageSubtitle>
           <Options visible={ticket === "presential" ? true : false}>
             <Option

--- a/src/pages/Dashboard/Payment/index.js
+++ b/src/pages/Dashboard/Payment/index.js
@@ -15,6 +15,7 @@ import {
 export default function Payment() {
   const [hasSubscription, setHasSubscription] = useState("");
   const [loading, setLoading] = useState(false);
+  const [ticket, setTicket] = useState(null);
   const { enrollment } = useApi();
 
   useEffect(() => { 
@@ -38,11 +39,17 @@ export default function Payment() {
         <>
           <PageSubtitle>Primeiro, escolha sua modalidade de ingresso</PageSubtitle>
           <Options>
-            <Option>
+            <Option
+              selected={ticket === "presential" ? true : false}
+              onClick={() => ticket === "presential" ? setTicket(null) : setTicket("presential")}
+            >
               <Type>Presencial</Type>
               <Price>R$250</Price>
             </Option>
-            <Option>
+            <Option
+              selected={ticket === "online" ? true : false}
+              onClick={() => ticket === "online" ? setTicket(null) : setTicket("online")}
+            >
               <Type>Online</Type>
               <Price>R$100</Price>
             </Option>

--- a/src/pages/Dashboard/Payment/index.js
+++ b/src/pages/Dashboard/Payment/index.js
@@ -4,6 +4,8 @@ import Loading from "../../../components/Loading";
 import { PageTitle, PageSubtitle, Center, BlockedText } from "../../../components/DefaultTabStyle";
 import TicketSelection from "./TicketSelection";
 import HotelSelection from "./HotelSelection";
+import Button from "../../../components/Form/Button";
+import styled from "styled-components";
 
 export default function Payment() {
   const [hasSubscription, setHasSubscription] = useState("");
@@ -60,6 +62,7 @@ export default function Payment() {
             setHasHotel={setHasHotel}
           />
           <PageSubtitle visible={controlVisibility()}>Fechado! O total ficou em R$ {total}. Agora é só confirmar:</PageSubtitle>
+          <ToPaymentButton visible={controlVisibility()}>RESERVAR INGRESSO</ToPaymentButton>
         </> :
         <Center>
           {loading ? <Loading /> : <BlockedText>Você precisa completar sua inscrição antes de prosseguir pra escolha de ingresso</BlockedText>}
@@ -67,3 +70,7 @@ export default function Payment() {
     </>
   );
 }
+
+const ToPaymentButton = styled(Button)`
+  display: ${props => props.visible ? "inblock" : "none !important"};
+`;

--- a/src/pages/Dashboard/Payment/index.js
+++ b/src/pages/Dashboard/Payment/index.js
@@ -1,18 +1,17 @@
 import { useState, useEffect } from "react";
 import useApi from "../../../hooks/useApi";
 import Loading from "../../../components/Loading";
-import { PageTitle, PageSubtitle, Center, BlockedText } from "../../../components/DefaultTabStyle";
-import TicketSelection from "./TicketSelection";
-import HotelSelection from "./HotelSelection";
-import Button from "../../../components/Form/Button";
-import styled from "styled-components";
+import { PageTitle, Center, BlockedText } from "../../../components/DefaultTabStyle";
+import ModalitySelection from "./ModalitySelection";
+import PaymentSelection from "./PaymentSelection";
+import useLocalStorage from "../../../hooks/useLocalStorage";
 
 export default function Payment() {
   const [hasSubscription, setHasSubscription] = useState("");
   const [loading, setLoading] = useState(false);
-  const [ticket, setTicket] = useState(null);
-  const [hasHotel, setHasHotel] = useState(null);
-  const [total, setTotal] = useState("0");
+  const [modalityInfo, setModalityInfo] = useLocalStorage("modalityInfo", {});
+  const [paymentVisibility, setPaymentVisibility] = useState(false);
+
   const { enrollment } = useApi();
 
   useEffect(() => { 
@@ -29,48 +28,24 @@ export default function Payment() {
       });
   }, [hasSubscription]);
 
-  useEffect(() => {
-    const ticketValue = ticket === "presential" ? 250 : 100;
-    const hotelValue = hasHotel === "yes" ? 350 : 0;
-
-    setTotal(ticketValue + hotelValue);
-  }, [hasHotel, ticket]);
-
-  const controlVisibility = () => { 
-    if (ticket === "online") {
-      return true;
-    }
-    if (ticket === "presential" && hasHotel) {
-      return true;
-    }
-    return false;
-  };
-
   return (
     <>
       <PageTitle>Ingresso e pagamento</PageTitle>
       {hasSubscription ?
         <>
-          <TicketSelection
-            ticket={ticket}
-            setTicket={setTicket}
-            setHasHotel={setHasHotel}
+          <ModalitySelection
+            setModalityInfo={setModalityInfo}
+            setPaymentVisibility={setPaymentVisibility}
           />
-          <HotelSelection
-            ticket={ticket}
-            hasHotel={hasHotel}
-            setHasHotel={setHasHotel}
+          <PaymentSelection
+            modalityInfo={modalityInfo}
+            paymentVisibility={paymentVisibility}
           />
-          <PageSubtitle visible={controlVisibility()}>Fechado! O total ficou em R$ {total}. Agora é só confirmar:</PageSubtitle>
-          <ToPaymentButton visible={controlVisibility()}>RESERVAR INGRESSO</ToPaymentButton>
-        </> :
+        </>
+        :
         <Center>
           {loading ? <Loading /> : <BlockedText>Você precisa completar sua inscrição antes de prosseguir pra escolha de ingresso</BlockedText>}
         </Center>}
     </>
   );
 }
-
-const ToPaymentButton = styled(Button)`
-  display: ${props => props.visible ? "inblock" : "none !important"};
-`;

--- a/src/pages/Dashboard/Payment/index.js
+++ b/src/pages/Dashboard/Payment/index.js
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import useApi from "../../../hooks/useApi";
 import Loading from "../../../components/Loading";
-import { PageTitle, Center, BlockedText } from "../../../components/DefaultTabStyle";
+import { PageTitle, PageSubtitle, Center, BlockedText } from "../../../components/DefaultTabStyle";
 import TicketSelection from "./TicketSelection";
 import HotelSelection from "./HotelSelection";
 
@@ -10,6 +10,7 @@ export default function Payment() {
   const [loading, setLoading] = useState(false);
   const [ticket, setTicket] = useState(null);
   const [hasHotel, setHasHotel] = useState(null);
+  const [total, setTotal] = useState("0");
   const { enrollment } = useApi();
 
   useEffect(() => { 
@@ -26,6 +27,23 @@ export default function Payment() {
       });
   }, [hasSubscription]);
 
+  useEffect(() => {
+    const ticketValue = ticket === "presential" ? 250 : 100;
+    const hotelValue = hasHotel === "yes" ? 350 : 0;
+
+    setTotal(ticketValue + hotelValue);
+  }, [hasHotel, ticket]);
+
+  const controlVisibility = () => { 
+    if (ticket === "online") {
+      return true;
+    }
+    if (ticket === "presential" && hasHotel) {
+      return true;
+    }
+    return false;
+  };
+
   return (
     <>
       <PageTitle>Ingresso e pagamento</PageTitle>
@@ -41,6 +59,7 @@ export default function Payment() {
             hasHotel={hasHotel}
             setHasHotel={setHasHotel}
           />
+          <PageSubtitle visible={controlVisibility()}>Fechado! O total ficou em R$ {total}. Agora é só confirmar:</PageSubtitle>
         </> :
         <Center>
           {loading ? <Loading /> : <BlockedText>Você precisa completar sua inscrição antes de prosseguir pra escolha de ingresso</BlockedText>}

--- a/src/pages/Dashboard/Payment/index.js
+++ b/src/pages/Dashboard/Payment/index.js
@@ -1,17 +1,9 @@
 import { useState, useEffect } from "react";
 import useApi from "../../../hooks/useApi";
 import Loading from "../../../components/Loading";
-import {
-  PageTitle,
-  PageSubtitle,
-  Options,
-  Option,
-  Type,
-  Price,
-  Center,
-  BlockedText,
-} from "../../../components/DefaultTabStyle";
+import { PageTitle, Center, BlockedText } from "../../../components/DefaultTabStyle";
 import TicketSelection from "./TicketSelection";
+import HotelSelection from "./HotelSelection";
 
 export default function Payment() {
   const [hasSubscription, setHasSubscription] = useState("");
@@ -44,23 +36,11 @@ export default function Payment() {
             setTicket={setTicket}
             setHasHotel={setHasHotel}
           />
-          <PageSubtitle visible={ticket === "presential" ? true : false}>Ótimo! Agora escolha sua modalidade de hospedagem</PageSubtitle>
-          <Options visible={ticket === "presential" ? true : false}>
-            <Option
-              selected={hasHotel === "no" ? true : false}
-              onClick={() => hasHotel === "no" ? setHasHotel(null) : setHasHotel("no")}
-            >
-              <Type>Sem Hotel</Type>
-              <Price>+ R$ 0</Price>
-            </Option>
-            <Option
-              selected={hasHotel === "yes" ? true : false}
-              onClick={() => hasHotel === "yes" ? setHasHotel(null) : setHasHotel("yes")}
-            >
-              <Type>Com Hotel</Type>
-              <Price>+ R$ 350</Price>
-            </Option>
-          </Options>
+          <HotelSelection
+            ticket={ticket}
+            hasHotel={hasHotel}
+            setHasHotel={setHasHotel}
+          />
         </> :
         <Center>
           {loading ? <Loading /> : <BlockedText>Você precisa completar sua inscrição antes de prosseguir pra escolha de ingresso</BlockedText>}


### PR DESCRIPTION
Fala galera!
Acabei terminando a feature e colocando tudo em um único PR mesmo, acho que acabou fazendo mais sentido.

Ao clicar em **RESERVAR INGRESSO**, um objeto é armazenado no local storage com a key "modalityInfo" em um objeto no formato:

`{
   modality: "presential" || "online",
   acommodation: "yes" || "no",
}`

O objeto pode ser acessado pelo state "modalityInfo", controlado pelo index!
@calilrenner , criei um componente chamado "PaymentSelection.js" para implementar seu display de pagamento sem conflitar, o controle da visibilidade da seção de pagamento também está sob controle do index.

Qualquer dúvida ou alteração que queiram fazer/sugerir, só dar um toque! :)